### PR TITLE
feat: reduce calls to CI and cache npm installs

### DIFF
--- a/.github/actions/setup-npm/action.yml
+++ b/.github/actions/setup-npm/action.yml
@@ -28,6 +28,7 @@ runs:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.scope }}
+        cache: 'npm'
 
     - name: 🔑 Prepare .npmrc from example
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,9 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [master]
-  push:
-    branches: [master]
-  workflow_dispatch: # Allows manual triggering from GitHub UI
+  workflow_call: # Allows this workflow to be called from other workflows
 
 jobs:
   validate:

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -2,8 +2,8 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
+  workflow_dispatch: # Allows manual triggering from GitHub UI
 
 permissions:
   contents: read
@@ -16,7 +16,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate:
+    uses: ./.github/workflows/CI.yml
+
   deploy:
+    needs: validate
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.npmrc.example
+++ b/.npmrc.example
@@ -2,5 +2,5 @@
 @torian12321:registry=https://npm.pkg.github.com
 
 # https://github.com/settings/tokens
-# Create a GitHub personal access token (classic) with read:packages and write:packages.
+# Create a GitHub personal access token (classic) with read:packages.
 //npm.pkg.github.com/:_authToken=NPMRC_NODE_AUTH_TOKEN


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

For more background, see ticket [#L3D-123](url_link)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable npm caching and make CI reusable via workflow_call, adding a CI validation job before GitHub Pages deploy.
> 
> - **CI/CD**:
>   - **CI workflow** (`.github/workflows/CI.yml`): switch triggers to `pull_request` and `workflow_call` (removes direct `push`/manual triggers) to allow reuse from other workflows.
>   - **GitHub Pages workflow** (`.github/workflows/gh_pages.yml`):
>     - Adds `workflow_dispatch` and normalizes `push` branches.
>     - Introduces `validate` job that reuses `CI.yml`; `deploy` now `needs: validate`.
> - **Actions**:
>   - **Setup NPM** (`.github/actions/setup-npm/action.yml`): enable `actions/setup-node` caching with `cache: 'npm'`.
> - **Config**:
>   - **.npmrc.example**: update token guidance to only require `read:packages`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c09fb633bc8d372946b73cb690714b5608da2d08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->